### PR TITLE
Add Pyroscope monitoring to prod cluster

### DIFF
--- a/monitoring/controllers/base/pyroscope/kustomization.yaml
+++ b/monitoring/controllers/base/pyroscope/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: monitoring
 resources:
-  - prometheus
-  - loki
-  - pyroscope
+  - repository.yaml
+  - release.yaml

--- a/monitoring/controllers/base/pyroscope/release.yaml
+++ b/monitoring/controllers/base/pyroscope/release.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pyroscope
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: pyroscope
+      version: "0.2.92"
+      sourceRef:
+        kind: HelmRepository
+        name: pyroscope-charts
+      interval: 12h
+

--- a/monitoring/controllers/base/pyroscope/repository.yaml
+++ b/monitoring/controllers/base/pyroscope/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: pyroscope-charts
+spec:
+  interval: 24h
+  url: https://pyroscope-io.github.io/helm-chart

--- a/monitoring/controllers/prod/pyroscope/kustomization.yaml
+++ b/monitoring/controllers/prod/pyroscope/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: monitoring
 resources:
-  - prometheus
-  - loki
-  - pyroscope
+  - ../../base/pyroscope


### PR DESCRIPTION
## Summary
- add Pyroscope Helm release as a base monitoring component
- include Pyroscope in the prod monitoring controllers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68519fcdf6f08322893a21e02c7faec9